### PR TITLE
rm zygote from deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
 NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Evolutionary = "0.5"

--- a/src/StochasticOptimizers.jl
+++ b/src/StochasticOptimizers.jl
@@ -9,7 +9,7 @@ using Evolutionary
 using Evolutionary: AbstractOptimizer
 using Distributions
 using ProgressMeter
-import Zygote
+using ForwardDiff
 
 import Evolutionary: CMAES, optimize, update_state!
 

--- a/test/policy_grad.jl
+++ b/test/policy_grad.jl
@@ -7,12 +7,17 @@ function noisy_rosenbrock(x::Vector)
     return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
 end
 
+function rosenbrock(x::Vector)
+    return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+end
+
 @testset "policy grad" begin
     μ, sqrtσ = ones(2) + 1e-2 * randn(2), ones(2)
     # mean(noisy_rosenbrock(rand.(Normal.(μ, sqrtσ.^2))) for _ in 1:1000)
 
     μ, sqrtσ = optimize(noisy_rosenbrock, μ, sqrtσ , PolicyGrad())
     expect = mean(noisy_rosenbrock(rand.(Normal.(μ, sqrtσ.^2))) for _ in 1:1000)
-
     @test expect < 3
+    expect = mean(rosenbrock(rand.(Normal.(μ, sqrtσ.^2))) for _ in 1:1000)
+    @test expect < 1
 end


### PR DESCRIPTION
ForwardDiff is faster.
## before
```julia repl
julia> @time using StochasticOptimizers
 16.661819 seconds (35.69 M allocations: 2.015 GiB, 4.18% gc time)
```
## after
```julia repl
julia> @time using StochasticOptimizers
  9.011561 seconds (11.67 M allocations: 655.179 MiB, 3.24% gc time)
```